### PR TITLE
fix(build,arm64): 增加-buildvcs=false选项，以便在arm64环境编译通过

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 ifneq ($(DLV),)
 	GO_BUILD_FLAGS += -gcflags "all=-N -l"
 endif
-GO_BUILD_FLAGS+=-mod vendor
+GO_BUILD_FLAGS+=-mod vendor -buildvcs=false
 
 export GO111MODULE=on
 


### PR DESCRIPTION
## 这个 PR 实现什么功能/修复什么问题:

* 增加-buildvcs=false选项，以便在arm64环境编译通过

## 是否需要 backport 到之前的 release 分支:

* release/3.9
* release/3.10