### PR TITLE
Automated cherry pick of #136: fix(build,arm64): 增加-buildvcs=false选项，以便在arm64环境编译通过

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 ifneq ($(DLV),)
 	GO_BUILD_FLAGS += -gcflags "all=-N -l"
 endif
-GO_BUILD_FLAGS+=-mod vendor
+GO_BUILD_FLAGS+=-mod vendor -buildvcs=false
 
 export GO111MODULE=on
 


### PR DESCRIPTION
Cherry pick of #136 on release/3.10.

#136: fix(build,arm64): 增加-buildvcs=false选项，以便在arm64环境编译通过